### PR TITLE
MapSource class methods for get max/min zoom doesn't work properly

### DIFF
--- a/mapview/source.py
+++ b/mapview/source.py
@@ -128,12 +128,12 @@ class MapSource(object):
     def get_min_zoom(self):
         """Return the minimum zoom of this source
         """
-        return 0
+        return self.min_zoom
 
     def get_max_zoom(self):
         """Return the maximum zoom of this source
         """
-        return 19
+        return self.max_zoom
 
     def fill_tile(self, tile):
         """Add this tile to load within the downloader


### PR DESCRIPTION
The current methods in the MapSource class for retrieve the max/min
zoom need to be changed to the real values of the class attributes. When
the user tries to do zoom in for above of the level 19, mapview
collapses.
