### PR TITLE
Raise exception if MBTilesMapSource finds a vector map

### DIFF
--- a/mapview/mbtsource.py
+++ b/mapview/mbtsource.py
@@ -27,6 +27,8 @@ class MBTilesMapSource(MapSource):
         # read metadata
         c = self.db.cursor()
         metadata = dict(c.execute("SELECT * FROM metadata"))
+        if metadata["format"] == "pbf":
+            raise ValueError("Only raster maps are supported, not vector maps.")
         self.min_zoom = int(metadata["minzoom"])
         self.max_zoom = int(metadata["maxzoom"])
         self.attribution = metadata.get("attribution", "")


### PR DESCRIPTION
I mistakenly thought all MBTiles files were the same but some are vector formatted and do not load in garden.mapview. This pull request hopefully prevents confusion for the next person who makes the same mistake.
