### PR TITLE
cater for mapview marker reposition for GridLayout/BoxLayout

### DIFF
--- a/mapview/view.py
+++ b/mapview/view.py
@@ -316,9 +316,9 @@ class MapView(Widget):
         """Returns the bounding box from the bottom/left (lat1, lon1) to
         top/right (lat2, lon2).
         """
-        x1, y1 = self.to_local(0 - margin, 0 - margin)
-        x2, y2 = self.to_local((self.width + margin),
-                               (self.height + margin))
+        x1, y1 = self.to_local(self.pos[0] - margin, self.pos[1] - margin)
+        x2, y2 = self.to_local((self.pos[0] + self.width + margin),
+                               (self.pos[1] + self.height + margin))
         c1 = self.get_latlon_at(x1, y1)
         c2 = self.get_latlon_at(x2, y2)
         return Bbox((c1.lat, c1.lon, c2.lat, c2.lon))


### PR DESCRIPTION
When mapView is used in GridLayout/BoxLayout or other types of layout which does not occupy the entire window or when not located at the bottom left, the mapMarker will get clipped by the bbox calculated assuming mapView starts at position 0,0. 