### PR TITLE
mapView can now be used in mixed layouts, such as GridLayout, BoxLayout etc.

### DIFF
--- a/mapview/view.py
+++ b/mapview/view.py
@@ -341,6 +341,8 @@ class MapView(Widget):
         y = ms.get_y(zoom, lat) - vy
         x *= scale
         y *= scale
+        x = x + self.pos[0]
+        y = y + self.pos[1]
         return x, y
 
     def center_on(self, *args):

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -316,9 +316,9 @@ class MapView(Widget):
         """Returns the bounding box from the bottom/left (lat1, lon1) to
         top/right (lat2, lon2).
         """
-        x1, y1 = self.to_local(0 - margin, 0 - margin)
-        x2, y2 = self.to_local((self.width + margin),
-                               (self.height + margin))
+        x1, y1 = self.to_local(self.pos[0] - margin, self.pos[1] - margin)
+        x2, y2 = self.to_local((self.pos[0] + self.width + margin),
+                               (self.pos[1] + self.height + margin))
         c1 = self.get_latlon_at(x1, y1)
         c2 = self.get_latlon_at(x2, y2)
         return Bbox((c1.lat, c1.lon, c2.lat, c2.lon))

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -316,9 +316,9 @@ class MapView(Widget):
         """Returns the bounding box from the bottom/left (lat1, lon1) to
         top/right (lat2, lon2).
         """
-        x1, y1 = self.to_local(self.pos[0] - margin, self.pos[1] - margin)
-        x2, y2 = self.to_local((self.pos[0] + self.width + margin),
-                               (self.pos[1] + self.height + margin))
+        x1, y1 = self.to_local(0 - margin, 0 - margin)
+        x2, y2 = self.to_local((self.width + margin),
+                               (self.height + margin))
         c1 = self.get_latlon_at(x1, y1)
         c2 = self.get_latlon_at(x2, y2)
         return Bbox((c1.lat, c1.lon, c2.lat, c2.lon))


### PR DESCRIPTION
when using the mapview I noticed that when placed in layouts when the mapview position is other than y:0, the markers will be misplaced. There are other quick solutions on the web saying use FloatLayout but that is not my desired way of fixing things, because FloatLayout will still bring the mapView to y=0.  

fix and properly tested on my own app. 