### PR TITLE
Fixed error about a missing __disabled_count property when using this…

### DIFF
--- a/mapview/view.py
+++ b/mapview/view.py
@@ -302,6 +302,7 @@ class MapView(Widget):
     _zoom = NumericProperty(0)
     _pause = BooleanProperty(False)
     _scale = 1.
+    _disabled_count = 0
 
     __events__ = ["on_map_relocated"]
 


### PR DESCRIPTION
When trying to run with kivy 1.10.1 the following error occurs
` File "/home/pi/.kivy/garden/garden.mapview/mapview/view.py", line 513, in __init__
     self.add_widget(self._scatter)
   File "/home/pi/.kivy/garden/garden.mapview/mapview/view.py", line 561, in add_widget
     super(MapView, self).add_widget(widget)
   File "/home/pi/triptracker/ui/touchscreen-app/.venv/lib/python3.5/site-packages/kivy/uix/widget.py", line 534, in add_widget
     widget._disabled_count = self._disabled_count
 AttributeError: 'MapView' object has no attribute '_disabled_count'
`

Fixed this by adding this field to mapview.py
