### PR TITLE
Introduce Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build/*
 cache/*
 examples/cache/*
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+
+language: python
+
+python:
+  - "2.7"
+  - "3.6"
+
+install: pip install tox-travis
+
+script: tox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mapview
 
+[![Build Status](https://travis-ci.org/kivy-garden/garden.mapview.svg?branch=master)](https://travis-ci.org/kivy-garden/garden.mapview)
+
 Mapview is a Kivy widget for displaying interactive maps. It has been
 designed with lot of inspirations of
 [Libchamplain](https://wiki.gnome.org/Projects/libchamplain) and

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = pep8
+skipsdist = True
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements.txt
+    flake8
+
+[testenv:pep8]
+commands = flake8 mapview/ examples/
+
+[flake8]
+ignore =
+    E122, E125, E126, E127, E128, E261, E265, E301, E302, E303, E402, E501,
+    E502, E712, E722, E999, F401, F811, W293, W504


### PR DESCRIPTION
Relies on #61 and makes sures build is always green via Travis CI.
Build is green on my fork, see: https://travis-ci.org/AndreMiras/garden.mapview/builds/472708895