### PR TITLE
Introduces simple mapview UI & unit test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+.git/
+.tox/
+*.pyc
+**/__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
-sudo: false
+sudo: required
 
-language: python
+language: generic
 
-python:
-  - "2.7"
-  - "3.6"
+env:
+  global:
+    - DISPLAY=:99.0
 
-install: pip install tox-travis
+services:
+  - docker
 
-script: tox
+before_install:
+  - sudo apt update -qq > /dev/null
+  - sudo apt install --yes --no-install-recommends xvfb
+
+install:
+  - docker build --tag=mapview-linux .
+
+before_script:
+  - sh -e /etc/init.d/xvfb start
+
+script:
+  - docker run -e DISPLAY=unix$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix mapview-linux /bin/sh -c 'tox'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Docker image for installing dependencies on Linux and running tests.
+# Build with:
+# docker build --tag=mapview-linux .
+# Run with:
+# docker run mapview-linux /bin/sh -c 'tox'
+# Or for interactive shell:
+# docker run -it --rm mapview-linux
+FROM ubuntu:18.04
+
+# configure locale
+RUN apt update -qq > /dev/null && apt install --yes --no-install-recommends \
+    locales && \
+    locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
+# install system dependencies
+RUN apt update -qq > /dev/null && apt install --yes --no-install-recommends \
+	python2.7-minimal libpython2.7-dev virtualenv make lsb-release pkg-config git build-essential \
+    sudo libssl-dev tox
+
+# install kivy system dependencies
+# https://kivy.org/docs/installation/installation-linux.html#dependencies-with-sdl2
+RUN apt install --yes --no-install-recommends \
+    libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
+
+WORKDIR /app
+COPY . /app

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -231,7 +231,6 @@ class MarkerMapLayer(MapLayer):
         mapview = self.parent
         set_marker_position = self.set_marker_position
         bbox = None
-        latest_bbox_size = dp(48)
         # reposition the markers depending the latitude
         markers = sorted(self.markers, key=lambda x: -x.lat)
         margin = max((max(marker.size) for marker in markers))

--- a/tests/test_mapview.py
+++ b/tests/test_mapview.py
@@ -1,0 +1,18 @@
+import unittest
+from mapview import MapView
+
+
+class TextInputTest(unittest.TestCase):
+
+    def test_init_simple_map(self):
+        """
+        Makes sure we can initialize a simple MapView object.
+        """
+        kwargs = {}
+        mapview = MapView(**kwargs)
+        self.assertEqual(len(mapview.children), 2)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,23 @@
 [tox]
-envlist = pep8
+envlist = pep8,py27
 skipsdist = True
+# trick to enable pre-installation of Cython
+# https://stackoverflow.com/a/50081741/185510
+indexserver =
+    preinstall = https://pypi.python.org/simple
 
 [testenv]
+passenv = DISPLAY XDG_RUNTIME_DIR
+basepython = python2.7
 deps =
+    :preinstall: Cython==0.28.2
     -r{toxinidir}/requirements.txt
-    flake8
+    kivy
+commands =
+    python -m unittest discover --top-level-directory=. --start-directory=tests/
 
 [testenv:pep8]
+deps = flake8
 commands = flake8 mapview/ examples/
 
 [flake8]


### PR DESCRIPTION
Makes sure `MapView` object initializes under Python2.
Exports `DISPLAY` and `XDG_RUNTIME_DIR` so `tox` can initialize the UI.
Prepares the ground for the Python3 SyntaxError, refs #51, #54 and #55.
Everything is tested through Docker to deal with system dependencies.
Also fixes PEP8 F841, `latest_bbox_size` got unused in d00bfa4.