### PR TITLE
Various PEP8 fixes and test against py36

### DIFF
--- a/examples/clustered_geojson.py
+++ b/examples/clustered_geojson.py
@@ -2,7 +2,7 @@ from kivy.base import runTouchApp
 import sys
 
 if __name__ == '__main__' and __package__ is None:
-    from os import sys, path
+    from os import path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from mapview import MapView, MapMarker

--- a/examples/map_with_marker_popup.py
+++ b/examples/map_with_marker_popup.py
@@ -3,7 +3,7 @@ from kivy.base import runTouchApp
 from kivy.lang import Builder
 
 if __name__ == '__main__' and __package__ is None:
-    from os import sys, path
+    from os import path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 import mapview

--- a/examples/simple_geojson.py
+++ b/examples/simple_geojson.py
@@ -2,7 +2,7 @@ from kivy.base import runTouchApp
 import sys
 
 if __name__ == '__main__' and __package__ is None:
-    from os import sys, path
+    from os import path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from mapview import MapView, MapMarker

--- a/examples/simple_map.py
+++ b/examples/simple_map.py
@@ -2,7 +2,7 @@ import sys
 from kivy.base import runTouchApp
 
 if __name__ == '__main__' and __package__ is None:
-    from os import sys, path
+    from os import path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from mapview import MapView, MapSource

--- a/examples/simple_mbtiles.py
+++ b/examples/simple_mbtiles.py
@@ -12,7 +12,7 @@ import sys
 from kivy.base import runTouchApp
 
 if __name__ == '__main__' and __package__ is None:
-    from os import sys, path
+    from os import path
     sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 from mapview import MapView
 from mapview.mbtsource import MBTilesMapSource

--- a/mapview/clustered_marker_layer.py
+++ b/mapview/clustered_marker_layer.py
@@ -195,7 +195,6 @@ class KDBush(object):
                         result.append(ids[i])
                 continue
 
-
             m = int(floor((left + right) / 2.))
 
             x = coords[2 * m]
@@ -261,6 +260,7 @@ class Marker(object):
     def __repr__(self):
         return "<Marker lon={} lat={} source={}>".format(self.lon, self.lat,
                                                          self.source)
+
 
 class SuperCluster(object):
     """Port of supercluster from mapbox in pure python
@@ -353,8 +353,10 @@ class SuperCluster(object):
                     num_points2 = 1
                     if isinstance(b, Cluster):
                         num_points2 = b.num_points
-                    b.zoom = zoom # save the zoom (so it doesn't get processed twice)
-                    wx += b.x * num_points2 # accumulate coordinates for calculating weighted center
+                    # save the zoom (so it doesn't get processed twice)
+                    b.zoom = zoom
+                    #  accumulate coordinates for calculating weighted center
+                    wx += b.x * num_points2
                     wy += b.y * num_points2
                     num_points += num_points2
                     b.parent_id = i
@@ -372,6 +374,7 @@ class ClusterMapMarker(MapMarker):
     cluster = ObjectProperty()
     num_points = NumericProperty()
     text_color = ListProperty([.1, .1, .1, 1])
+
     def on_cluster(self, instance, cluster):
         self.num_points = cluster.num_points
 

--- a/mapview/geojson.py
+++ b/mapview/geojson.py
@@ -27,7 +27,6 @@ from kivy.graphics import Mesh, Line, Color
 from kivy.graphics.tesselator import Tesselator, WINDING_ODD, TYPE_POLYGONS
 from kivy.utils import get_color_from_hex
 from kivy.metrics import dp
-from kivy.utils import get_color_from_hex
 from mapview import CACHE_DIR
 from mapview.view import MapLayer
 from mapview.downloader import Downloader

--- a/mapview/mbtsource.py
+++ b/mapview/mbtsource.py
@@ -75,7 +75,7 @@ class MBTilesMapSource(MapSource):
         # no-file loading
         try:
             data = io.BytesIO(row[0])
-        except:
+        except Exception:
             # android issue, "buffer" does not have the buffer interface
             # ie row[0] buffer is not compatible with BytesIO on Android??
             data = io.BytesIO(bytes(row[0]))

--- a/mapview/source.py
+++ b/mapview/source.py
@@ -30,11 +30,11 @@ class MapSource(object):
         "thunderforest-transport": (0, 0, 19, "http://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png", attribution_thunderforest),
         "thunderforest-landscape": (0, 0, 19, "http://{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png", attribution_thunderforest),
         "thunderforest-outdoors": (0, 0, 19, "http://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png", attribution_thunderforest),
-        
+
         # no longer available
         #"mapquest-osm": (0, 0, 19, "http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpeg", "Tiles Courtesy of Mapquest", {"subdomains": "1234", "image_ext": "jpeg"}),
         #"mapquest-aerial": (0, 0, 19, "http://oatile{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpeg", "Tiles Courtesy of Mapquest", {"subdomains": "1234", "image_ext": "jpeg"}),
-        
+
         # more to add with
         # https://github.com/leaflet-extras/leaflet-providers/blob/master/leaflet-providers.js
         # not working ?
@@ -43,11 +43,11 @@ class MapSource(object):
     }
 
     def __init__(self,
-        url="http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        cache_key=None, min_zoom=0, max_zoom=19, tile_size=256,
-        image_ext="png",
-        attribution="© OpenStreetMap contributors",
-        subdomains="abc", **kwargs):
+            url="http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            cache_key=None, min_zoom=0, max_zoom=19, tile_size=256,
+            image_ext="png",
+            attribution="© OpenStreetMap contributors",
+            subdomains="abc", **kwargs):
         super(MapSource, self).__init__()
         if cache_key is None:
             # possible cache hit, but very unlikely
@@ -91,7 +91,7 @@ class MapSource(object):
         """
         lat = clamp(-lat, MIN_LATITUDE, MAX_LATITUDE)
         lat = lat * pi / 180.
-        return ((1.0 - log(tan(lat) + 1.0 / cos(lat)) / pi) / \
+        return ((1.0 - log(tan(lat) + 1.0 / cos(lat)) / pi) /
             2. * pow(2., zoom)) * self.dp_tile_size
 
     def get_lon(self, zoom, x):

--- a/mapview/types.py
+++ b/mapview/types.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 Coordinate = namedtuple("Coordinate", ["lat", "lon"])
 
+
 class Bbox(tuple):
     def collide(self, *args):
         if isinstance(args[0], Coordinate):

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -587,7 +587,7 @@ class MapView(Widget):
     def animated_diff_scale_at(self, d, x, y):
         self._scale_target_time = 1.
         self._scale_target_pos = x, y
-        if self._scale_target_anim == False:
+        if self._scale_target_anim is False:
             self._scale_target_anim = True
             self._scale_target = d
         else:
@@ -798,7 +798,7 @@ class MapView(Widget):
             _, _ = bbox_for_zoom(vx / f, vy / f, w, h, tile.zoom)
 
             if tile_x < btile_x_first or tile_x >= btile_x_last or \
-                            tile_y < btile_y_first or tile_y >= btile_y_last:
+                    tile_y < btile_y_first or tile_y >= btile_y_last:
                 tile.state = "done"
                 self._tiles_bg.remove(tile)
                 self.canvas_map.before.remove(tile.g_color)
@@ -817,7 +817,7 @@ class MapView(Widget):
             tile_y = tile.tile_y
 
             if tile_x < tile_x_first or tile_x >= tile_x_last or \
-                            tile_y < tile_y_first or tile_y >= tile_y_last:
+                    tile_y < tile_y_first or tile_y >= tile_y_last:
                 tile.state = "done"
                 self.tile_map_set(tile_x, tile_y, False)
                 self._tiles.remove(tile)
@@ -837,8 +837,8 @@ class MapView(Widget):
         while arm_size < arm_max:
             for i in range(arm_size):
                 if not self.tile_in_tile_map(x, y) and \
-                                y >= tile_y_first and y < tile_y_last and \
-                                x >= tile_x_first and x < tile_x_last:
+                        y >= tile_y_first and y < tile_y_last and \
+                        x >= tile_x_first and x < tile_x_last:
                     self.load_tile(x, y, size, zoom)
 
                 x += dirs[turn % 4 + 1]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py27
+envlist = pep8,py27,py36
 skipsdist = True
 # trick to enable pre-installation of Cython
 # https://stackoverflow.com/a/50081741/185510
@@ -22,5 +22,5 @@ commands = flake8 mapview/ examples/
 
 [flake8]
 ignore =
-    E122, E125, E126, E127, E128, E261, E265, E301, E302, E303, E402, E501,
-    E502, E712, E722, E999, F401, F811, W293, W504
+    E122, E128, E265, E402, E501,
+    F401, W504


### PR DESCRIPTION
- E125 continuation line with same indent as next logical line
- E126 continuation line over-indented for hanging indent
- E127 continuation line over-indented for visual indent
- E261 at least two spaces before inline comment
- E301 expected 1 blank line
- E302 expected 2 blank lines
- E303 too many blank lines
- E502 the backslash is redundant between brackets
- E712 comparison to False should be 'if cond is False:' or 'if not cond:'
- E722 do not use bare 'except'
- E999 SyntaxError: invalid syntax
- F811 redefinition of unused 'sys' and 'get_color_from_hex'
- W293 blank line contains whitespace