### PR TITLE
Fixes downloader error on iOS

### DIFF
--- a/mapview/__init__.py
+++ b/mapview/__init__.py
@@ -20,12 +20,7 @@ MIN_LATITUDE = -90.
 MAX_LATITUDE = 90.
 MIN_LONGITUDE = -180.
 MAX_LONGITUDE = 180.
-if platform == 'ios':
-    # CACHE_DIR must be in a place where the user has read/write permissions
-    root_folder = App().user_data_dir
-    CACHE_DIR = os.path.join(root_folder, 'cache')
-else:
-    CACHE_DIR = "cache"
+CACHE_DIR = "cache"
 
 try:
     # fix if used within garden

--- a/mapview/__init__.py
+++ b/mapview/__init__.py
@@ -8,6 +8,10 @@ MapView
 MapView is a Kivy widget that display maps.
 """
 
+from kivy.utils import platform
+from kivy.app import App
+import os.path
+
 __all__ = ["Coordinate", "Bbox", "MapView", "MapSource", "MapMarker",
            "MapLayer", "MarkerMapLayer", "MapMarkerPopup"]
 __version__ = "0.2"
@@ -16,7 +20,12 @@ MIN_LATITUDE = -90.
 MAX_LATITUDE = 90.
 MIN_LONGITUDE = -180.
 MAX_LONGITUDE = 180.
-CACHE_DIR = "cache"
+if platform == 'ios':
+    # CACHE_DIR must be in a place where the user has read/write permissions
+    root_folder = App().user_data_dir
+    CACHE_DIR = os.path.join(root_folder, 'cache')
+else:
+    CACHE_DIR = "cache"
 
 try:
     # fix if used within garden

--- a/mapview/__init__.py
+++ b/mapview/__init__.py
@@ -8,9 +8,6 @@ MapView
 MapView is a Kivy widget that display maps.
 """
 
-from kivy.utils import platform
-from kivy.app import App
-import os.path
 
 __all__ = ["Coordinate", "Bbox", "MapView", "MapSource", "MapMarker",
            "MapLayer", "MarkerMapLayer", "MapMarkerPopup"]

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -23,6 +23,9 @@ from mapview import MIN_LONGITUDE, MAX_LONGITUDE, MIN_LATITUDE, MAX_LATITUDE, \
 from mapview.source import MapSource
 from mapview.utils import clamp
 from itertools import takewhile
+from kivy.utils import platform
+from os.path import join
+from kivy.app import App
 
 import webbrowser
 
@@ -310,7 +313,6 @@ class MapView(Widget):
     delta_x = NumericProperty(0)
     delta_y = NumericProperty(0)
     background_color = ListProperty([181 / 255., 208 / 255., 208 / 255., 1])
-    cache_dir = StringProperty(CACHE_DIR)
     _zoom = NumericProperty(0)
     _pause = BooleanProperty(False)
     _scale = 1.
@@ -512,6 +514,9 @@ class MapView(Widget):
     def __init__(self, **kwargs):
         from kivy.base import EventLoop
         EventLoop.ensure_window()
+        # CACHE_DIR must be in a place where the user has read/write permissions
+        self.cache_dir = self.cache_dir if platform != 'ios' else join(
+            App.get_running_app().user_data_dir, self.cache_dir)
         self._invalid_scale = True
         self._tiles = []
         self._tiles_bg = []

--- a/mapview/view.py
+++ b/mapview/view.py
@@ -515,8 +515,9 @@ class MapView(Widget):
         from kivy.base import EventLoop
         EventLoop.ensure_window()
         # CACHE_DIR must be in a place where the user has read/write permissions
-        self.cache_dir = self.cache_dir if platform != 'ios' else join(
-            App.get_running_app().user_data_dir, self.cache_dir)
+        if platform == 'ios':
+            app = App.get_running_app()
+            self.cache_dir = join(app.user_data_dir, self.cache_dir)
         self._invalid_scale = True
         self._tiles = []
         self._tiles_bg = []


### PR DESCRIPTION
Sets the CACHE_DIR variable to be in a folder where the user has write permissions when targeting the iOS platform. Without the fix, python keeps printing "downloader error" when trying to save new map tiles.